### PR TITLE
Add possible null if pointer

### DIFF
--- a/internal/ts/render.go
+++ b/internal/ts/render.go
@@ -194,6 +194,10 @@ func (r *TypeRender) writeStruct(ctx context, t *types.Struct) {
 			r.write(ctx, "?")
 		}
 		r.write(ctx, ": ")
+
+		if _, ok := t.Field(i).Type().(*types.Pointer); ok {
+			r.write(ctx, "null | ")
+		}
 		r.writeType(ctx, typ)
 		r.write(ctx, ",")
 		void = false


### PR DESCRIPTION
Pointers are possibly `nil` in golang thus I have added the optional `null | ` typescript type.